### PR TITLE
Add Poor Ores

### DIFF
--- a/Versions.md
+++ b/Versions.md
@@ -102,6 +102,7 @@ Current Mod Versions
 - **Ping** v1.0.2.B6
 - **PiP** v4.0.0
 - **PneumaticCraft** v1.5.2-50
+- **Poor Ores** v1.4.4
 - **ProjectRed Base** v4.5.8.59
 - **ProjectRed Compat** v4.5.8.59
 - **ProjectRed Integration** v4.5.8.59

--- a/Versions.md
+++ b/Versions.md
@@ -102,7 +102,7 @@ Current Mod Versions
 - **Ping** v1.0.2.B6
 - **PiP** v4.0.0
 - **PneumaticCraft** v1.5.2-50
-- **Poor Ores** v1.4.4
+- **Poor Ores** v1.4.6
 - **ProjectRed Base** v4.5.8.59
 - **ProjectRed Compat** v4.5.8.59
 - **ProjectRed Integration** v4.5.8.59

--- a/config/Metallurgy.cfg
+++ b/config/Metallurgy.cfg
@@ -13,7 +13,7 @@ generators {
     B:Carmot=false
     B:Ceruclase=true
     B:Copper=false
-    B:DeepIron=true
+    B:DeepIron=false
     B:Eximite=true
     B:Ignatius=false
     B:Infuscolium=true
@@ -124,7 +124,7 @@ generators {
 
     deepiron {
         I:chunk_chance=20
-        S:dimensions=-100 -19 -6 -5
+        S:dimensions=-100
         I:max_Y_level=255
         I:min_Y_level=1
         I:ores_per_vein=8

--- a/config/PoorOres.cfg
+++ b/config/PoorOres.cfg
@@ -1,0 +1,176 @@
+# Configuration file
+
+general {
+    # Enable/Disable recipes for crafting [default: true]
+    B:add_crafting=true
+
+    # Enable/Disable recipes for smelting [default: true]
+    B:add_smelting=true
+
+    # Enable/Disable worldgen for coal [default: false]
+    B:baseWorldgenCoal=false
+
+    # Enable/Disable worldgen for diamond [default: false]
+    B:baseWorldgenDiamond=false
+
+    # Enable/Disable worldgen for emerald [default: false]
+    B:baseWorldgenEmerald=false
+
+    # Enable/Disable worldgen for gold [default: false]
+    B:baseWorldgenGold=false
+
+    # Enable/Disable worldgen for iron [default: false]
+    B:baseWorldgenIron=false
+
+    # Enable/Disable worldgen for lapis [default: false]
+    B:baseWorldgenLapis=false
+
+    # Enable/Disable worldgen for quartz [default: false]
+    B:baseWorldgenQuartz=false
+
+    # Enable/Disable worldgen for redstone [default: false]
+    B:baseWorldgenRedstone=false
+}
+
+
+ores {
+
+    block_coal {
+        S:baseBlock=coal_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:coal_ore
+        I:burnTime=200
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=120
+        I:veinRate=16
+        I:veinSize=48
+    }
+
+    block_diamond {
+        S:baseBlock=diamond_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:diamond_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=16
+        I:veinRate=4
+        I:veinSize=8
+    }
+
+    block_emerald {
+        S:baseBlock=emerald_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:emerald_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_gold {
+        S:baseBlock=gold_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:gold_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=32
+        I:veinRate=3
+        I:veinSize=32
+    }
+
+    block_iron {
+        S:baseBlock=iron_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:iron_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=64
+        I:veinRate=16
+        I:veinSize=32
+    }
+
+    block_lapis {
+        S:baseBlock=lapis_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:lapis_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=32
+        I:veinRate=8
+        I:veinSize=32
+    }
+
+    block_redstone {
+        S:baseBlock=redstone_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:redstone_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=16
+        I:veinRate=4
+        I:veinSize=32
+    }
+
+    block_quartz {
+        S:baseBlock=quartz_ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=minecraft:quartz_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=minecraft
+        I:nuggetRenderType=0
+        I:oreRenderType=2
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=128
+        I:veinRate=10
+        I:veinSize=64
+    }
+
+}
+
+

--- a/config/PoorOres.cfg
+++ b/config/PoorOres.cfg
@@ -13,7 +13,7 @@ general {
     # Enable/Disable worldgen for diamond [default: false]
     B:baseWorldgenDiamond=false
 
-    # Enable/Disable worldgen for emerald [default: false]
+    # Enable/Disable worldgen for emerald (currently not working) [default: true]
     B:baseWorldgenEmerald=false
 
     # Enable/Disable worldgen for gold [default: false]
@@ -44,6 +44,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0x363636
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
@@ -61,6 +62,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0x4AEDD1
         I:nuggetRenderType=0
         I:oreRenderType=1
         S:underlyingBlock=minecraft:stone
@@ -78,6 +80,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0x17DD62
         I:nuggetRenderType=0
         I:oreRenderType=1
         S:underlyingBlock=minecraft:stone
@@ -95,6 +98,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0xFFFF0B
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
@@ -112,6 +116,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0xFFFFFF
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
@@ -129,6 +134,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0x456ED1
         I:nuggetRenderType=0
         I:oreRenderType=1
         S:underlyingBlock=minecraft:stone
@@ -146,6 +152,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=minecraft
+        S:nuggetColor=0xFF0000
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
@@ -163,6 +170,7 @@ ores {
         S:dimWhiteList=
         B:isDust=false
         S:modID=minecraft
+        S:nuggetColor=0xEAE4DE
         I:nuggetRenderType=0
         I:oreRenderType=2
         S:underlyingBlock=minecraft:netherrack
@@ -758,6 +766,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=Metallurgy
+        S:nuggetColor=0xFFF200
         I:nuggetRenderType=0
         I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
@@ -775,6 +784,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=Metallurgy
+        S:nuggetColor=0xA27777
         I:nuggetRenderType=0
         I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
@@ -792,6 +802,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=Metallurgy
+        S:nuggetColor=0xC5C5BA
         I:nuggetRenderType=0
         I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
@@ -826,6 +837,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=Metallurgy
+        S:nuggetColor=0x161616
         I:nuggetRenderType=0
         I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
@@ -843,6 +855,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=Metallurgy
+        S:nuggetColor=0xC27603
         I:nuggetRenderType=0
         I:oreRenderType=7
         S:underlyingBlock=minecraft:stone

--- a/config/PoorOres.cfg
+++ b/config/PoorOres.cfg
@@ -351,7 +351,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=2
+        I:oreRenderType=3
         S:underlyingBlock=minecraft:end_stone
         I:veinHeight=0
         I:veinRate=0
@@ -368,7 +368,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=2
+        I:oreRenderType=3
         S:underlyingBlock=minecraft:end_stone
         I:veinHeight=0
         I:veinRate=0
@@ -385,7 +385,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -402,7 +402,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -419,7 +419,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -436,7 +436,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -453,7 +453,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -470,7 +470,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -487,7 +487,7 @@ ores {
         B:isDust=false
         S:modID=ThermalFoundation
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -504,7 +504,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -521,7 +521,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -538,7 +538,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -555,7 +555,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=4
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -572,7 +572,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -589,7 +589,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -606,7 +606,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -623,7 +623,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -640,7 +640,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -657,7 +657,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -674,7 +674,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -691,7 +691,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -708,7 +708,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -725,7 +725,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=1
+        I:oreRenderType=5
         S:underlyingBlock=minecraft:netherrack
         I:veinHeight=0
         I:veinRate=0
@@ -742,7 +742,7 @@ ores {
         B:isDust=false
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=6
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -759,7 +759,7 @@ ores {
         B:isDust=true
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -776,7 +776,7 @@ ores {
         B:isDust=true
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -793,7 +793,7 @@ ores {
         B:isDust=true
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -810,7 +810,7 @@ ores {
         B:isDust=true
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -827,7 +827,7 @@ ores {
         B:isDust=true
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0
@@ -844,7 +844,7 @@ ores {
         B:isDust=true
         S:modID=Metallurgy
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=7
         S:underlyingBlock=minecraft:stone
         I:veinHeight=0
         I:veinRate=0

--- a/config/PoorOres.cfg
+++ b/config/PoorOres.cfg
@@ -39,7 +39,7 @@ ores {
         S:baseBlock=coal_ore
         I:baseBlockMeta=0
         S:baseBlockTexture=minecraft:coal_ore
-        I:burnTime=200
+        I:burnTime=160
         S:dimBlackList=
         S:dimWhiteList=
         B:isDust=false
@@ -47,9 +47,9 @@ ores {
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
-        I:veinHeight=120
-        I:veinRate=16
-        I:veinSize=48
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
     block_diamond {
@@ -62,11 +62,11 @@ ores {
         B:isDust=false
         S:modID=minecraft
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=1
         S:underlyingBlock=minecraft:stone
-        I:veinHeight=16
-        I:veinRate=4
-        I:veinSize=8
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
     block_emerald {
@@ -98,9 +98,9 @@ ores {
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
-        I:veinHeight=32
-        I:veinRate=3
-        I:veinSize=32
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
     block_iron {
@@ -115,9 +115,9 @@ ores {
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
-        I:veinHeight=64
-        I:veinRate=16
-        I:veinSize=32
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
     block_lapis {
@@ -130,11 +130,11 @@ ores {
         B:isDust=false
         S:modID=minecraft
         I:nuggetRenderType=0
-        I:oreRenderType=0
+        I:oreRenderType=1
         S:underlyingBlock=minecraft:stone
-        I:veinHeight=32
-        I:veinRate=8
-        I:veinSize=32
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
     block_redstone {
@@ -149,9 +149,9 @@ ores {
         I:nuggetRenderType=0
         I:oreRenderType=0
         S:underlyingBlock=minecraft:stone
-        I:veinHeight=16
-        I:veinRate=4
-        I:veinSize=32
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
     block_quartz {
@@ -166,9 +166,689 @@ ores {
         I:nuggetRenderType=0
         I:oreRenderType=2
         S:underlyingBlock=minecraft:netherrack
-        I:veinHeight=128
-        I:veinRate=10
-        I:veinSize=64
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_copper {
+        S:baseBlock=Ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Copper
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_tin {
+        S:baseBlock=Ore
+        I:baseBlockMeta=1
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Tin
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_silver {
+        S:baseBlock=Ore
+        I:baseBlockMeta=2
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Silver
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_lead {
+        S:baseBlock=Ore
+        I:baseBlockMeta=3
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Lead
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_nickel {
+        S:baseBlock=Ore
+        I:baseBlockMeta=4
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Nickel
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_platinum {
+        S:baseBlock=Ore
+        I:baseBlockMeta=5
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Platinum
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_aluminum {
+        S:baseBlock=tile.gcBlockCore
+        I:baseBlockMeta=7
+        S:baseBlockTexture=galacticraftcore:oreAluminum
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=GalacticraftCore
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_osmium {
+        S:baseBlock=OreBlock
+        I:baseBlockMeta=0
+        S:baseBlockTexture=mekanism:OsmiumOre
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Mekanism
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_yellorite {
+        S:baseBlock=YelloriteOre
+        I:baseBlockMeta=0
+        S:baseBlockTexture=bigreactors:oreYellorite
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=BigReactors
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_manganese {
+        S:baseBlock=base.ore
+        I:baseBlockMeta=2
+        S:baseBlockTexture=metallurgy:base/manganese_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_eximite {
+        S:baseBlock=ender.ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=metallurgy:ender/eximite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=2
+        S:underlyingBlock=minecraft:end_stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_meutoite {
+        S:baseBlock=ender.ore
+        I:baseBlockMeta=1
+        S:baseBlockTexture=metallurgy:ender/meutoite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=2
+        S:underlyingBlock=minecraft:end_stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_prometheum {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=metallurgy:fantasy/prometheum_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_deep_iron {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=1
+        S:baseBlockTexture=metallurgy:fantasy/deep_iron_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_infuscolium {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=2
+        S:baseBlockTexture=metallurgy:fantasy/infuscolium_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_oureclase {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=4
+        S:baseBlockTexture=metallurgy:fantasy/oureclase_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_astral_silver {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=5
+        S:baseBlockTexture=metallurgy:fantasy/astral_silver_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_carmot {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=6
+        S:baseBlockTexture=metallurgy:fantasy/carmot_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_mithril {
+        S:baseBlock=Ore
+        I:baseBlockMeta=6
+        S:baseBlockTexture=thermalfoundation:ore/Ore_Mithril
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=ThermalFoundation
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_rubracium {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=8
+        S:baseBlockTexture=metallurgy:fantasy/rubracium_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_orichalcum {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=11
+        S:baseBlockTexture=metallurgy:fantasy/orichalcum_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_adamantine {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=13
+        S:baseBlockTexture=metallurgy:fantasy/adamantine_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_atlarus {
+        S:baseBlock=fantasy.ore
+        I:baseBlockMeta=14
+        S:baseBlockTexture=metallurgy:fantasy/atlarus_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_ignatius {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=metallurgy:nether/ignatius_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_shadow_iron {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=1
+        S:baseBlockTexture=metallurgy:nether/shadow_iron_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_lemurite {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=2
+        S:baseBlockTexture=metallurgy:nether/lemurite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_midasium {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=3
+        S:baseBlockTexture=metallurgy:nether/midasium_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_vyroxeres {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=4
+        S:baseBlockTexture=metallurgy:nether/vyroxeres_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_ceruclase {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=5
+        S:baseBlockTexture=metallurgy:nether/ceruclase_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_alduorite {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=6
+        S:baseBlockTexture=metallurgy:nether/alduorite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_kalendrite {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=7
+        S:baseBlockTexture=metallurgy:nether/kalendrite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_vulcanite {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=8
+        S:baseBlockTexture=metallurgy:nether/vulcanite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_sanguinite {
+        S:baseBlock=nether.ore
+        I:baseBlockMeta=9
+        S:baseBlockTexture=metallurgy:nether/sanguinite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=1
+        S:underlyingBlock=minecraft:netherrack
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_zinc {
+        S:baseBlock=precious.ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=metallurgy:precious/zinc_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=false
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_sulfur {
+        S:baseBlock=utility.ore
+        I:baseBlockMeta=0
+        S:baseBlockTexture=metallurgy:utility/sulfur_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_phosphorite {
+        S:baseBlock=utility.ore
+        I:baseBlockMeta=1
+        S:baseBlockTexture=metallurgy:utility/phosphorite_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_saltpeter {
+        S:baseBlock=utility.ore
+        I:baseBlockMeta=2
+        S:baseBlockTexture=metallurgy:utility/saltpeter_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_magnesium {
+        S:baseBlock=utility.ore
+        I:baseBlockMeta=3
+        S:baseBlockTexture=metallurgy:utility/magnesium_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_bitumen {
+        S:baseBlock=utility.ore
+        I:baseBlockMeta=4
+        S:baseBlockTexture=metallurgy:utility/bitumen_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
+    }
+
+    block_potash {
+        S:baseBlock=utility.ore
+        I:baseBlockMeta=5
+        S:baseBlockTexture=metallurgy:utility/potash_ore
+        I:burnTime=0
+        S:dimBlackList=
+        S:dimWhiteList=
+        B:isDust=true
+        S:modID=Metallurgy
+        I:nuggetRenderType=0
+        I:oreRenderType=0
+        S:underlyingBlock=minecraft:stone
+        I:veinHeight=0
+        I:veinRate=0
+        I:veinSize=0
     }
 
 }

--- a/config/PoorOres.cfg
+++ b/config/PoorOres.cfg
@@ -820,6 +820,7 @@ ores {
         S:dimWhiteList=
         B:isDust=true
         S:modID=Metallurgy
+        S:nuggetColor=0x655440
         I:nuggetRenderType=0
         I:oreRenderType=7
         S:underlyingBlock=minecraft:stone

--- a/config/cofh/world/AE2-Ores.json
+++ b/config/cofh/world/AE2-Ores.json
@@ -31,8 +31,10 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
+            -19,
             -1,
-            1
+            1,
+            7
         ],
         "enabled":false
     },
@@ -63,8 +65,10 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
+            -19,
             -1,
-            1
+            1,
+            7
         ]
     }
 }

--- a/config/cofh/world/BigReactors-Ores.json
+++ b/config/cofh/world/BigReactors-Ores.json
@@ -33,8 +33,7 @@
         ],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -5,
-            -4,
+            -19,
             -1,
             1,
             7

--- a/config/cofh/world/BigReactors-Ores.json
+++ b/config/cofh/world/BigReactors-Ores.json
@@ -1,7 +1,16 @@
 {
     "yellorite": {
         "template": "fractal",
-        "block": "BigReactors:YelloriteOre",
+        "block": [
+            {
+                "name": "BigReactors:YelloriteOre",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_yellorite_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 32,
         "numClusters": 32,

--- a/config/cofh/world/MagicalCrops-Ores.json
+++ b/config/cofh/world/MagicalCrops-Ores.json
@@ -31,14 +31,10 @@
                 "entry": "Sacred Springs"
             }
         ],
-        "dimensionRestriction": "blacklist",
+        "dimensionRestriction": "whitelist",
         "dimensions": [
-            -100,
-            -19,
-            -5,
-            -4,
-            -1,
-            1
+            0,
+            7
         ]
     }
 }

--- a/config/cofh/world/Mekanism-Ores.json
+++ b/config/cofh/world/Mekanism-Ores.json
@@ -1,7 +1,16 @@
 {
     "osmium": {
         "template": "fractal",
-        "block": "Mekanism:OreBlock",
+        "block": [
+            {
+                "name": "Mekanism:OreBlock",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_osmium_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 16,
         "numClusters": 96,

--- a/config/cofh/world/Mekanism-Ores.json
+++ b/config/cofh/world/Mekanism-Ores.json
@@ -25,9 +25,13 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
+            -100,
+            -19,
             -1,
+            0,
             1,
             7
-        ]
+        ],
+        "enabled": false 
     }
 }

--- a/config/cofh/world/Metallurgy-Ores.json
+++ b/config/cofh/world/Metallurgy-Ores.json
@@ -5,12 +5,20 @@
             {
                 "name": "Metallurgy:fantasy.ore",
                 "metadata": 4,
-                "weight": 90
+                "weight": 81
+            },
+            {
+                "name": "PoorOres:poor_oureclase_ore",
+                "weight": 9
             },
             {
                 "name": "Metallurgy:fantasy.ore",
                 "metadata": 6,
-                "weight": 10
+                "weight": 9
+            },
+            {
+                "name": "PoorOres:poor_carmot_ore",
+                "weight": 1
             }
         ],
         "material": "stone",
@@ -38,12 +46,20 @@
             {
                 "name": "Metallurgy:fantasy.ore",
                 "metadata": 6,
-                "weight": 80
+                "weight": 72
+            },
+            {
+                "name": "PoorOres:poor_carmot_ore",
+                "weight": 8
             },
             {
                 "name": "Metallurgy:fantasy.ore",
                 "metadata": 4,
-                "weight": 20
+                "weight": 8
+            },
+            {
+                "name": "PoorOres:poor_oureclase_ore",
+                "weight": 2
             }
         ],
         "material": "stone",
@@ -129,10 +145,17 @@
     },
     "atlarus": {
         "template": "fractal",
-        "block": {
-            "name": "Metallurgy:fantasy.ore",
-            "metadata": 14
-        },
+        "block": [
+            {
+                "name": "Metallurgy:fantasy.ore",
+                "metadata": 14,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_atlarus_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 16,
         "numClusters": 32,
@@ -161,10 +184,17 @@
     },
     "vyroxeres": {
         "template": "fractal",
-        "block": {
-            "name": "Metallurgy:nether.ore",
-            "metadata": 4
-        },
+        "block": [
+            {
+                "name": "Metallurgy:nether.ore",
+                "metadata": 4,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_vyroxeres_ore",
+                "weight": 10
+            }
+        ],
         "material": "netherrack",
         "clusterSize": 32,
         "numClusters": 32,
@@ -189,10 +219,17 @@
     },
     "ignatius": {
         "template": "underfluid",
-        "block": {
-            "name": "Metallurgy:nether.ore",
-            "metadata": 0
-        },
+        "block": [
+            {
+                "name": "Metallurgy:nether.ore",
+                "metadata": 0,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_ignatius_ore",
+                "weight": 10
+            }
+        ],
         "material": "netherrack",
         "genFluid": "lava",
         "clusterSize": 4,
@@ -215,10 +252,17 @@
     },
     "vulcanite": {
         "template": "underfluid",
-        "block": {
-            "name": "Metallurgy:nether.ore",
-            "metadata": 8
-        },
+        "block": [
+            {
+                "name": "Metallurgy:nether.ore",
+                "metadata": 8,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_vulcanite_ore",
+                "weight": 10
+            }
+        ],
         "material": "netherrack",
         "genFluid": "lava",
         "clusterSize": 4,
@@ -241,10 +285,17 @@
     },
     "sanguinite": {
         "template": "underfluid",
-        "block": {
-            "name": "Metallurgy:nether.ore",
-            "metadata": 9
-        },
+        "block": [
+            {
+                "name": "Metallurgy:nether.ore",
+                "metadata": 9,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_sanguinite_ore",
+                "weight": 10
+            }
+        ],
         "material": "netherrack",
         "genFluid": "hell_blood",
         "clusterSize": 4,
@@ -267,10 +318,17 @@
     },
     "zinc": {
         "template": "fractal",
-        "block": {
-            "name": "Metallurgy:precious.ore",
-            "metadata": 0
-        },
+        "block": [
+            {
+                "name": "Metallurgy:precious.ore",
+                "metadata": 0,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_zinc_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 16,
         "numClusters": 96,
@@ -296,10 +354,17 @@
     },
     "sulfur": {
         "template": "underfluid",
-        "block": {
-            "name": "Metallurgy:utility.ore",
-            "metadata": 0
-        },
+        "block": [
+            {
+                "name": "Metallurgy:utility.ore",
+                "metadata": 0,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_sulfur_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "genFluid": "lava",
         "clusterSize": 4,
@@ -325,12 +390,16 @@
             {
                 "name": "Metallurgy:utility.ore",
                 "metadata": 3,
-                "weight": 92
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_magnesium_ore",
+                "weight": 8
             },
             {
                 "name": "BiomesOPlenty:gemOre",
                 "metadata": 4,
-                "weight": 8
+                "weight": 2
             }
         ],
         "material": "stone",
@@ -356,10 +425,17 @@
     },
     "bitumen": {
         "template": "underfluid",
-        "block": {
-            "name": "Metallurgy:utility.ore",
-            "metadata": 4
-        },
+        "block": [
+            {
+                "name": "Metallurgy:utility.ore",
+                "metadata": 4,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_bitumen_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "genFluid": "oil",
         "clusterSize": 4,

--- a/config/cofh/world/Metallurgy-Ores.json
+++ b/config/cofh/world/Metallurgy-Ores.json
@@ -182,6 +182,36 @@
             7
         ]
     },
+    "deepIron": {
+        "template": "fractal",
+        "block": [
+            {
+                "name": "Metallurgy:fantasy.ore",
+                "metadata": 1,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_deep_iron_ore",
+                "weight": 10
+            }
+        ],
+        "material": "stone",
+        "clusterSize": 16,
+        "numClusters": 96,
+        "chunkChance": 192,
+        "minHeight": 1,
+        "veinHeight": 32,
+        "veinDiameter": 64,
+        "verticalDensity": 16,
+        "horizontalDensity": 16,
+        "retrogen": false,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -100
+        ]
+    },
     "vyroxeres": {
         "template": "fractal",
         "block": [
@@ -199,7 +229,7 @@
         "clusterSize": 32,
         "numClusters": 32,
         "chunkChance": 128,
-        "minHeight": 1,
+        "minHeight": 32,
         "veinHeight": 64,
         "veinDiameter": 64,
         "verticalDensity": 16,
@@ -376,7 +406,6 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
             -1,
             1,
@@ -416,7 +445,6 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
             -1,
             1,
@@ -447,7 +475,6 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
             -1,
             1,
@@ -595,7 +622,6 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
             -1,
             1,
@@ -618,7 +644,6 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
             -1,
             1,

--- a/config/cofh/world/PoorOres-Ores.json
+++ b/config/cofh/world/PoorOres-Ores.json
@@ -1,0 +1,554 @@
+{
+    "poorCoal": {
+        "template": "uniform",
+        "block": "PoorOres.poor_coal_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 3,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorIron": {
+        "template": "uniform",
+        "block": "PoorOres.poor_iron_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 2,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorGold": {
+        "template": "uniform",
+        "block": "PoorOres.poor_gold_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 2,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorRedstone": {
+        "template": "uniform",
+        "block": "PoorOres.poor_redstone_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 3,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorLapis": {
+        "template": "uniform",
+        "block": "PoorOres.poor_lapis_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 2,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorAluminum": {
+        "template": "uniform",
+        "block": "PoorOres.poor_aluminum_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorCopper": {
+        "template": "uniform",
+        "block": "PoorOres.poor_copper_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 2,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorTin": {
+        "template": "uniform",
+        "block": "PoorOres.poor_tin_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorSilver": {
+        "template": "uniform",
+        "block": "PoorOres.poor_silver_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorLead": {
+        "template": "uniform",
+        "block": "PoorOres.poor_lead_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorNickel": {
+        "template": "uniform",
+        "block": "PoorOres.poor_nickel_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorPlatinum": {
+        "template": "uniform",
+        "block": "PoorOres.poor_platinum_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorMithril": {
+        "template": "uniform",
+        "block": "PoorOres.poor_mithril_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "whitelist",
+        "biomes": [
+            {
+                "type": "name",
+                "entry": "Enchanted Forest"
+            },
+            {
+                "type": "name",
+                "entry": "Magical Forest"
+            },
+            {
+                "type": "name",
+                "entry": "Mystic Grove"
+            },
+            {
+                "type": "name",
+                "entry": "Sacred Springs"
+            }
+        ],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -100
+            -19,
+            0,
+            7
+        ]
+    },
+    "poorYellorite": {
+        "template": "uniform",
+        "block": "PoorOres.poor_yellorite_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "whitelist",
+        "biomes": [
+            {
+                "type": "dictionary",
+                "entry": [
+                    "DEAD",
+                    "WASTELAND"
+                ]
+            }
+        ],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorOureclase": {
+        "template": "uniform",
+        "block": "PoorOres.poor_oureclase_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -100,
+            -19,
+            7
+        ]
+    },
+    "poorCarmot": {
+        "template": "uniform",
+        "block": "PoorOres.poor_carmot_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -100,
+            -19,
+            7
+        ]
+    },
+    "poorAtlarus": {
+        "template": "uniform",
+        "block": "PoorOres.poor_atlarus_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [
+            {
+                "type": "name",
+                "entry": "Dark Forest"
+            },
+            {
+                "type": "name",
+                "entry": "Dark Forest Center"
+            }
+        ],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -100,
+            -19,
+            7
+        ]
+    },
+    "poorDeepIron": {
+        "template": "uniform",
+        "block": "PoorOres.poor_deep_iron_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -100
+        ]
+    },
+    "poorVyroxeres": {
+        "template": "uniform",
+        "block": "PoorOres.poor_vyroxeres_ore",
+        "material": "minecraft:netherrack",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 32,
+        "maxHeight": 96,
+        "retrogen": true,
+        "biomeRestriction": "whitelist",
+        "biomes": [
+            {
+                "type": "name",
+                "entry": "Undergarden"
+            }
+        ],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -1
+        ]
+    },
+    "poorIgnatius": {
+        "template": "uniform",
+        "block": "PoorOres.poor_ignatius_ore",
+        "material": "minecraft:netherrack",
+        "clusterSize": 8,
+        "numClusters": 7,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "blacklist",
+        "biomes": [
+            {
+                "type": "name",
+                "entry": "Phantasmagoric Inferno"
+            }
+        ],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -1
+        ]
+    },
+    "poorVulcanite": {
+        "template": "uniform",
+        "block": "PoorOres.poor_vulcanite_ore",
+        "material": "minecraft:netherrack",
+        "clusterSize": 8,
+        "numClusters": 7,
+        "minHeight": 1,
+        "maxHeight": 32,
+        "retrogen": true,
+        "biomeRestriction": "whitelist",
+        "biomes": [
+            {
+                "type": "name",
+                "entry": "Phantasmagoric Inferno"
+            }
+        ],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -1
+        ]
+    },
+    "poorSanguinite": {
+        "template": "uniform",
+        "block": "PoorOres.poor_sanguinite_ore",
+        "material": "minecraft:netherrack",
+        "clusterSize": 8,
+        "numClusters": 7,
+        "minHeight": 1,
+        "maxHeight": 128,
+        "retrogen": true,
+        "biomeRestriction": "whitelist",
+        "biomes": [
+            {
+                "type": "name",
+                "entry": "Visceral Heap"
+            }
+        ],
+        "dimensionRestriction": "whitelist",
+        "dimensions": [
+            -1
+        ]
+    },
+    "poorZinc": {
+        "template": "uniform",
+        "block": "PoorOres.poor_zinc_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorSulfur": {
+        "template": "uniform",
+        "block": "PoorOres.poor_sulfur_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 7,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorMagnesium": {
+        "template": "uniform",
+        "block": "PoorOres.poor_magnesium_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 2,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorBitumen": {
+        "template": "uniform",
+        "block": "PoorOres.poor_bitumen_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 7,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -19,
+            -1,
+            1,
+            7
+        ]
+    },
+    "poorOsmium": {
+        "template": "uniform",
+        "block": "PoorOres.poor_osmium_ore",
+        "material": "minecraft:stone",
+        "clusterSize": 8,
+        "numClusters": 1,
+        "minHeight": 1,
+        "maxHeight": 64,
+        "retrogen": true,
+        "biomeRestriction": "none",
+        "biomes": [],
+        "dimensionRestriction": "blacklist",
+        "dimensions": [
+            -100,
+            -19,
+            -1,
+            0,
+            1,
+            7
+        ],
+        "enabled": false
+    }
+}

--- a/config/cofh/world/TConstruct-Ores.json
+++ b/config/cofh/world/TConstruct-Ores.json
@@ -51,8 +51,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -5,
-            -4,
+            -19,
             -1,
             1,
             7

--- a/config/cofh/world/TConstruct-Ores.json
+++ b/config/cofh/world/TConstruct-Ores.json
@@ -5,7 +5,11 @@
             {
                 "name": "GalacticraftCore:tile.gcBlockCore",
                 "metadata": 7,
-                "weight": 95
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_aluminum_ore",
+                "weight": 5
             },
             {
                 "name": "BiomesOPlenty:gemOre",

--- a/config/cofh/world/ThermalExpansion-Ores.json
+++ b/config/cofh/world/ThermalExpansion-Ores.json
@@ -31,10 +31,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -67,10 +64,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -112,10 +106,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -157,10 +148,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -202,10 +190,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7

--- a/config/cofh/world/ThermalExpansion-Ores.json
+++ b/config/cofh/world/ThermalExpansion-Ores.json
@@ -5,7 +5,11 @@
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 0,
-                "weight": 98
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_copper_ore",
+                "weight": 8
             },
             {
                 "name": "BiomesOPlenty:gemOre",
@@ -38,10 +42,17 @@
     },
     "tin": {
         "template": "fractal",
-        "block": {
-            "name": "ThermalFoundation:Ore",
-            "metadata": 1
-        },
+        "block": [
+            {
+                "name": "ThermalFoundation:Ore",
+                "metadata": 1,
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_tin_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 16,
         "numClusters": 96,
@@ -71,12 +82,20 @@
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 2,
-                "weight": 80
+                "weight": 72
+            },
+            {
+                "name": "PoorOres:poor_silver_ore",
+                "weight": 8
             },
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 3,
-                "weight": 20
+                "weight": 18
+            },
+            {
+                "name": "PoorOres:poor_lead_ore",
+                "weight": 2
             }
         ],
         "material": "stone",
@@ -108,12 +127,20 @@
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 3,
-                "weight": 90
+                "weight": 81
+            },
+            {
+                "name": "PoorOres:poor_lead_ore",
+                "weight": 9
             },
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 2,
-                "weight": 10
+                "weight": 9
+            },
+            {
+                "name": "PoorOres:poor_silver_ore",
+                "weight": 1
             }
         ],
         "material": "stone",
@@ -145,11 +172,19 @@
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 4,
+                "weight": 855
+            },
+            {
+                "name": "PoorOres:poor_nickel_ore",
                 "weight": 95
             },
             {
                 "name": "ThermalFoundation:Ore",
                 "metadata": 5,
+                "weight": 45
+            },
+            {
+                "name": "PoorOres:poor_platinum_ore",
                 "weight": 5
             }
         ],
@@ -178,10 +213,17 @@
     },
     "mithril": {
         "template": "fractal",
-        "block": {
-            "name": "ThermalFoundation:Ore",
-            "metadata": 6
-        },
+        "block": [
+            {
+                "name": "ThermalFoundation:Ore",
+                "metadata": 6,
+                "wegiht": 90
+            },
+            {
+                "name": "PoorOres:poor_mithril_ore",
+                "weight": 10
+            },
+        ],
         "material": "stone",
         "clusterSize": 16,
         "numClusters": 96,

--- a/config/cofh/world/Vanilla.json
+++ b/config/cofh/world/Vanilla.json
@@ -68,7 +68,16 @@
     },
     "coal": {
         "template": "fractal",
-        "block": "coal_ore",
+        "block": [
+            {
+                "name": "coal_ore",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_coal_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 32,
         "numClusters": 96,
@@ -129,10 +138,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -147,7 +153,7 @@
             },
             {
                 "name": "PoorOres:poor_gold_ore",
-                "weight": 90
+                "weight": 10
             }
         ],
         "material": "stone",
@@ -164,10 +170,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -182,7 +185,7 @@
             },
             {
                 "name": "PoorOres:poor_redstone_ore",
-                "weight": 90
+                "weight": 10
             }
         ],
         "material": "stone",
@@ -199,10 +202,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -226,10 +226,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -262,10 +259,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7
@@ -318,10 +312,7 @@
         "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
-            -100,
             -19,
-            -5,
-            -4,
             -1,
             1,
             7

--- a/config/cofh/world/Vanilla.json
+++ b/config/cofh/world/Vanilla.json
@@ -93,7 +93,11 @@
         "block": [
             {
                 "name": "iron_ore",
-                "weight": 985
+                "weight": 900
+            },
+            {
+                "name": "PoorOres:poor_iron_ore",
+                "weight": 85
             },
             {
                 "name": "BiomesOPlenty:gemOre",
@@ -136,7 +140,16 @@
     },
     "gold": {
         "template": "fractal",
-        "block": "gold_ore",
+        "block": [
+            {
+                "name": "gold_ore",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_gold_ore",
+                "weight": 90
+            }
+        ],
         "material": "stone",
         "clusterSize": 16,
         "numClusters": 96,
@@ -162,7 +175,16 @@
     },
     "redstone": {
         "template": "fractal",
-        "block": "redstone_ore",
+        "block": [
+            {
+                "name": "redstone_ore",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_redstone_ore",
+                "weight": 90
+            }
+        ],
         "material": "stone",
         "clusterSize": 32,
         "numClusters": 96,
@@ -216,7 +238,16 @@
     },
     "lapis": {
         "template": "fractal",
-        "block": "lapis_ore",
+        "block": [
+            {
+                "name": "lapis_ore",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_lapis_ore",
+                "weight": 10
+            }
+        ],
         "material": "stone",
         "clusterSize": 32,
         "numClusters": 64,
@@ -242,7 +273,16 @@
     },
     "quartz": {
         "template": "fractal",
-        "block": "quartz_ore",
+        "block": [
+            {
+                "name": "quartz_ore",
+                "weight": 90
+            },
+            {
+                "name": "PoorOres:poor_quartz_ore",
+                "weight": 10
+            }
+        ],
         "material": "netherrack",
         "clusterSize": 32,
         "numClusters": 144,


### PR DESCRIPTION
This should integrate poor ore versions into every fractal and underfluid ore generation configuration we have.  This also adds uniform poor ore veins throughout every chunk where appropriate, to make up for the loss of total average "ingots" per chunk from the fractal generations.

The ratio should be roughly 90% normal ores, 10% poor ores, unless there are secondary/tertiary/etc. ores within the fractal clouds, wherein they take up a portion of the 10% normally taken by the poor ore version.  For every poor ore found per chunk on average within the fractal cloud, there will be 1 vein of 8 poor ores found everywhere else, to try and even out the loss, and provide a way to find ores everywhere, without removing the need to explore.

I've also taken this time to move Deep Iron to the Deep Dark (as well as disable CoFH generation of osmium for now until we find a place to put it).

This should close #125.